### PR TITLE
fix: update gh copilot CLI invocation (suggest → -p / --allow-all-tools)

### DIFF
--- a/harness/runner.py
+++ b/harness/runner.py
@@ -15,7 +15,7 @@ def invoke_agent(repo_path: str, prompt: str) -> int:
         The process exit code.
     """
     result = subprocess.run(
-        ["gh", "copilot", "suggest", "-t", "shell", prompt],
+        ["gh", "copilot", "--", "-p", prompt, "--allow-all-tools"],
         cwd=repo_path,
     )
     return result.returncode

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, call, patch
 from harness.runner import invoke_agent
 
 
-def test_invoke_agent_calls_gh_copilot_suggest():
+def test_invoke_agent_calls_gh_copilot_with_prompt():
     mock_result = MagicMock()
     mock_result.returncode = 0
 
@@ -13,9 +13,10 @@ def test_invoke_agent_calls_gh_copilot_suggest():
 
     args, kwargs = mock_run.call_args
     cmd = args[0]
-    assert cmd[:4] == ["gh", "copilot", "suggest", "-t"]
-    assert "shell" in cmd
+    assert cmd[:3] == ["gh", "copilot", "--"]
+    assert "-p" in cmd
     assert "run harness" in cmd
+    assert "--allow-all-tools" in cmd
 
 
 def test_invoke_agent_passes_cwd(tmp_path):


### PR DESCRIPTION
The `gh copilot suggest -t shell` subcommand no longer exists. The current CLI uses `gh copilot -- -p "<prompt>" --allow-all-tools` for non-interactive mode.\n\nFixes the `unknown option '-t'` error seen when the run loop tries to invoke the agent.